### PR TITLE
Adding inline radio inputs

### DIFF
--- a/addon/components/frost-radio-group.js
+++ b/addon/components/frost-radio-group.js
@@ -7,9 +7,14 @@ export default Ember.Component.extend(PropTypeMixin, {
   layout,
 
   propTypes: {
-    hook: PropTypes.string,
+    hook: PropTypes.string.isRequired,
     id: PropTypes.string,
-    value: PropTypes.string
+    value: PropTypes.string,
+    inputs: PropTypes.arrayOf(PropTypes.shape({
+      disabled: PropTypes.bool,
+      label: PropTypes.string,
+      value: PropTypes.string
+    }))
   },
 
   getDefaultProps () {

--- a/addon/helpers/array.js
+++ b/addon/helpers/array.js
@@ -1,0 +1,18 @@
+import Ember from 'ember'
+const {
+  Helper: {
+    helper
+  }
+} = Ember
+
+export function array (params) {
+  // Temporary fix until the following bug is resolved: https://github.com/emberjs/ember.js/issues/14264
+  // initial code:
+  // return params
+
+  let array = Ember.A()
+  array.pushObjects(params)
+  return array
+}
+
+export default helper(array)

--- a/addon/templates/components/frost-radio-group.hbs
+++ b/addon/templates/components/frost-radio-group.hbs
@@ -1,1 +1,12 @@
-{{yield}}
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{#each inputs as |input|}}
+    {{#frost-radio-button
+      disabled=input.disabled
+      value=input.value
+    }}
+      {{if input.label input.label input.value}}
+    {{/frost-radio-button}}
+  {{/each}}
+{{/if}}

--- a/app/helpers/array.js
+++ b/app/helpers/array.js
@@ -1,0 +1,1 @@
+export { default, array } from 'ember-frost-core/helpers/array'

--- a/tests/dummy/app/pods/radio/controller.js
+++ b/tests/dummy/app/pods/radio/controller.js
@@ -3,6 +3,8 @@ const {Controller} = Ember
 
 // BEGIN-SNIPPET radio-controller
 export default Controller.extend({
+  inlineValue: 'a',
+
   sampleList1: ['a', 'b', 'c', 'd', 'e'],
   sampleList2: ['a', 'b', 'c', 'd', 'e'],
   sampleList3: ['a', 'b', 'c', 'd', 'e'],

--- a/tests/dummy/app/pods/radio/template.hbs
+++ b/tests/dummy/app/pods/radio/template.hbs
@@ -29,6 +29,31 @@
     </div>
   </div>
 
+  <div class="section-title">Inline</div>
+  <hr>
+  <div class='section'>
+    <div class='example'>
+      <div class='title'>Demo</div>
+      <div class='demo'>
+        {{! BEGIN-SNIPPET radio-inline }}
+        {{frost-radio-group
+          id='inline'
+          inputs=(array
+            (hash value='a')
+            (hash label='B' value='b')
+            (hash value='c' disabled=true)
+          )
+          onChange=(action (mut inlineValue) value='target.value')
+          value=inlineValue
+        }}
+        {{! END-SNIPPET }}
+      </div>
+      <div style='padding-top:15px' class='snippet'>
+        {{code-snippet name='radio-inline.hbs'}}
+      </div>
+    </div>
+  </div>
+
   <div class="section-title">Size</div>
   <hr>
   <div class='section'>


### PR DESCRIPTION
#minor#

Sorry @juwara0 I didn't want to hold up the process any longer, but I didn't have time to put in the tests or finish the spread operator.  I'll get back to spread later, but let's move forward with just the inline for now.

# CHANGELOG

* Radio button groups can now take `inputs` as an inline array